### PR TITLE
Uncomment message

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 spring.application.name=sb-rest-configmap
 
-#message=Hello, %s
+message=Hello, %s


### PR DESCRIPTION
"mvn clean install" fails if the message is commented out.

Error shown below:
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'greetingController': Injection of autowired dependencies failed; nested exception is java.lang.IllegalArgumentException: Could not resolve placeholder 'message' in string value "${message}"
	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessPropertyValues(AutowiredAnnotationBeanPostProcessor.java:355)